### PR TITLE
Changed .container__content max_width to 1400px instead of 80%

### DIFF
--- a/src/templates/container/container.import.less
+++ b/src/templates/container/container.import.less
@@ -5,7 +5,7 @@
 }
 
 .container__content {
-  max-width: 80%;
+  max-width: 1400px;
   margin: 0 auto;
   background-color: #FFF;
   box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.4);


### PR DESCRIPTION
A small but meaningful change that ensures pages that use the container template remain clear when zoomed out or on larger monitors. This change can be tested client-side by simply zooming out.
A comparison of before and after:
**Before: (80%)**
![image](https://user-images.githubusercontent.com/43861537/104522009-104b6d00-55cc-11eb-98d6-dd7a9c960f31.png)
**After: (1400px)**
![image](https://user-images.githubusercontent.com/43861537/104521980-ff026080-55cb-11eb-8734-bf036591f6c9.png)
