### PR TITLE
Make dropdowns close on focus exit (blur) #175

### DIFF
--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -1,9 +1,19 @@
 import React, { Component } from "react"
 import { Link } from "gatsby"
 
+const mouseLeave = (toggleExtended) => {
+  console.log("STOP IT")
+  if(toggleExtended) {
+    toggleExtended();
+  }
+};
+
 class Dropdown extends Component {
 
+
+
   render() {
+    const toggleExtended = this.props.toggleExtended;
     const title = this.props.title
     const extended = this.props.extended ? "show" : ""
     const { links } = this.props
@@ -13,7 +23,7 @@ class Dropdown extends Component {
         <div className="dropdown__button">
           {title} <i className={`fa fa-caret-down`}></i>
         </div>
-        <div className={`dropdown__content ${extended}`}>
+        <div className={`dropdown__content ${extended}`} onMouseLeave={()=>mouseLeave(toggleExtended)}>
           {links.map(link => {
             let filePath = `/${link.section}/${link.file}`
 

--- a/src/components/navbar/Navbar.js
+++ b/src/components/navbar/Navbar.js
@@ -146,6 +146,7 @@ class Navbar extends Component {
                 title="Outreach"
                 links={outreachLinks}
                 extended={this.state.outreachDropdown}
+                toggleExtended={this.toggleOutreachDropdown}
               />
             </div>
           </li>

--- a/src/components/navbar/Navbar.js
+++ b/src/components/navbar/Navbar.js
@@ -153,6 +153,7 @@ class Navbar extends Component {
             <div
               onClick={() => this.toggleIliteDropdown()}
               onKeyPress={this.handleKeyPress}
+              toggleExtended={this.toggleIliteDropdown}
               role="button"
               tabIndex={0}
             >
@@ -160,6 +161,8 @@ class Navbar extends Component {
                 title="About ILITE"
                 links={iliteLinks}
                 extended={this.state.iliteDropdown}
+                toggleExtended={this.toggleIliteDropdown}
+                onfocusout={()=>console.log("Focus out!")}
               />
             </div>
           </li>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
All of the pulldowns at the top of the screen will now exit when moved off. 

# Motivation and Context
It was annoying having the drop downs get stuck. Now they behave. 

# How has this been tested?
Tested in browser
# Screenshots (if appropriate):
![DropDownFix](https://user-images.githubusercontent.com/1112973/109895064-96933f80-7c5c-11eb-85db-d8296d7ee652.gif)


# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.